### PR TITLE
Simulate long life decays

### DIFF
--- a/src/PhysicsList.cpp
+++ b/src/PhysicsList.cpp
@@ -73,7 +73,7 @@ void PhysicsList::ConstructProcess() {
 
     G4RadioactiveDecay *radioactiveDecay = new G4RadioactiveDecay();
 
-    radioactiveDecay->SetThresholdForVeryLongDecayTime(100 * CLHEP::hour);
+    radioactiveDecay->SetThresholdForVeryLongDecayTime(pow(10,12) * CLHEP::hour);
 
     G4bool ARMflag = false;
     radioactiveDecay->SetARM(ARMflag);        //Atomic Rearangement

--- a/src/PhysicsList.cpp
+++ b/src/PhysicsList.cpp
@@ -73,7 +73,7 @@ void PhysicsList::ConstructProcess() {
 
     G4RadioactiveDecay *radioactiveDecay = new G4RadioactiveDecay();
 
-    radioactiveDecay->SetThresholdForVeryLongDecayTime(pow(10,12) * CLHEP::hour);
+    radioactiveDecay->SetThresholdForVeryLongDecayTime(pow(10,12) * CLHEP::year);
 
     G4bool ARMflag = false;
     radioactiveDecay->SetARM(ARMflag);        //Atomic Rearangement


### PR DESCRIPTION
To be able to simulate long life decays we have to use `G4RadioactiveDecay::SetThresholdForVeryLongDecayTime(double)` with a proper threshold. For example here I set 1e12 years. For reference, the mean life of U238 is 4.5e9 and for Th232 1e10 years
With this change, it seems that the U238 decays:
`./radiation-decay-secondaries -n 1 -p U238 -d G4_CONCRETE 100 -o test.root`
![u238](https://github.com/lobis/radiation-decay-secondaries/assets/106647320/98579777-5f4f-4c0b-ac4c-f61707516faa)

And Th232:
`./radiation-decay-secondaries -n 1 -p Th232 -d G4_CONCRETE 100 -o test.root`
![th232](https://github.com/lobis/radiation-decay-secondaries/assets/106647320/9ba9d900-038e-4807-a44c-525f2a6dd198)


See "**Note on the time threshold for radioactive decay of ions**" in this link: [https://geant4-userdoc.web.cern.ch/UsersGuides/ForApplicationDeveloper/html/TrackingAndPhysics/physicsProcess.html#particle-decay-process](https://geant4-userdoc.web.cern.ch/UsersGuides/ForApplicationDeveloper/html/TrackingAndPhysics/physicsProcess.html#particle-decay-process) 