### PR TITLE
Option to load user-defined materials

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,11 @@ project(radiation-decay-secondaries LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 20)
 
-find_package(ROOT REQUIRED COMPONENTS RIO Tree)
+message(STATUS "C++ standard: ${CMAKE_CXX_STANDARD}")
+message(STATUS "Compiler: ${CMAKE_CXX_COMPILER}")
+message(STATUS "Compiler ID: ${CMAKE_CXX_COMPILER_ID}")
+
+find_package(ROOT REQUIRED COMPONENTS RIO Tree XMLIO)
 find_package(Geant4 REQUIRED)
 
 include(FetchContent)
@@ -23,4 +27,12 @@ target_include_directories(${PROJECT_NAME} PRIVATE ${CMAKE_SOURCE_DIR}/src ${ROO
 file(GLOB SOURCES ${CMAKE_SOURCE_DIR}/src/*.cpp)
 target_sources(${PROJECT_NAME} PRIVATE ${SOURCES})
 
-target_link_libraries(${PROJECT_NAME} PRIVATE ${ROOT_LIBRARIES} ${Geant4_LIBRARIES} CLI11::CLI11 pthread)
+target_link_libraries(${PROJECT_NAME} PRIVATE 
+        ${ROOT_LIBRARIES}
+        ROOT::XMLIO 
+        ${Geant4_LIBRARIES} 
+        CLI11::CLI11 
+        pthread
+)
+
+message(STATUS "ROOT_LIBRARIES = ${ROOT_LIBRARIES}")

--- a/materials/materials.xml
+++ b/materials/materials.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<materials>
+
+    <material name="Concrete" state="solid">
+      <D value="2.3" unit="g/cm3"/>
+      <component material="G4_H" fraction="0.010000"/>
+      <component material="G4_C" fraction="0.001000"/>
+      <component material="G4_O" fraction="0.529107"/>
+      <component material="G4_Na" fraction="0.016000"/>
+      <component material="G4_Mg" fraction="0.002000"/>
+      <component material="G4_Al" fraction="0.033872"/>
+      <component material="G4_Si" fraction="0.337021" />
+      <component material="G4_K" fraction="0.013000"/>
+      <component material="G4_Ca" fraction="0.044000"/>
+      <component material="G4_Fe" fraction="0.014000"/>
+   </material>
+   
+    <material name="BorosilicateGlass" state="solid">
+        <D value="2.3" unit="g/cm3"/>
+        <component material="G4_SILICON_DIOXIDE" fraction="0.70"/>
+        <component material="G4_ALUMINUM_OXIDE" fraction="0.20"/>
+        <component material="G4_BORON_OXIDE" fraction="0.10"/>
+    </material>
+</materials>

--- a/src/DetectorConstruction.cpp
+++ b/src/DetectorConstruction.cpp
@@ -14,7 +14,9 @@ using namespace std;
 using namespace CLHEP;
 
 DetectorConstruction::DetectorConstruction(const std::vector<std::pair<std::string, double>> &configuration)
-        : G4VUserDetectorConstruction(), configuration(configuration) {}
+        : G4VUserDetectorConstruction(), configuration(configuration) {
+        LoadCustomMaterialsFromXML("../materials/materials.xml");
+}
 
 
 G4VPhysicalVolume *DetectorConstruction::Construct() {
@@ -22,9 +24,9 @@ G4VPhysicalVolume *DetectorConstruction::Construct() {
     auto nist = G4NistManager::Instance();
     const auto vacuum = nist->FindOrBuildMaterial("G4_Galactic");
 
-    // check all the materials are valid
+     // check all the materials are valid
     for (const auto &[material, thickness]: configuration) {
-        if (nist->FindOrBuildMaterial(material) == nullptr) {
+        if (GetMaterialOrCustom(material) == nullptr) {
             throw runtime_error("Material " + material + " not found");
         }
         if (thickness < 0) {
@@ -41,19 +43,23 @@ G4VPhysicalVolume *DetectorConstruction::Construct() {
     world = new G4PVPlacement(nullptr, {}, worldLogical, "World", nullptr, false, 0);
 
     totalThickness = 0;
-    for (int i = 0; i < configuration.size(); i++) {
+    for (size_t i = 0; i < configuration.size(); ++i) {
         const auto &config = configuration[i];
-        const auto material = nist->FindOrBuildMaterial(config.first);
-        const auto thickness = config.second * mm;
-        cout << "Layer " << i << " is " << thickness << " mm of " << material->GetName() << endl;
+        G4Material* material = GetMaterialOrCustom(config.first);
+        double thickness = config.second * mm;
+
+        cout << "Layer " << i << ": " << thickness/mm << " mm of " << material->GetName() << endl;
+
         if (thickness == 0) {
-            cout << "Warning: Layer " << i << " has zero thickness, skipping it" << endl;
+            cout << "Warning: Layer " << i << " has zero thickness, skipping." << endl;
             continue;
         }
+
         auto solid = new G4Box("Layer" + to_string(i), width / 2, width / 2, thickness / 2);
         auto logical = new G4LogicalVolume(solid, material, "Layer" + to_string(i));
         new G4PVPlacement(nullptr, {0, 0, totalThickness + thickness / 2}, logical, "Layer" + to_string(i),
                           worldLogical, false, 0);
+
         totalThickness += thickness;
     }
 
@@ -81,4 +87,148 @@ double DetectorConstruction::GetThickness() {
     return detectorConstruction->totalThickness;
 }
 
+void DetectorConstruction::LoadCustomMaterialsFromXML(const std::string& filename) {
+    TXMLEngine xml;
+    XMLDocPointer_t doc = xml.ParseFile(filename.c_str());
+    if (!doc) {
+        throw std::runtime_error("Cannot load materials XML file: " + filename);
+    }
+
+    XMLNodePointer_t root = xml.DocGetRootElement(doc);
+    if (std::string(xml.GetNodeName(root)) != "materials") {
+        throw std::runtime_error("Root node must be <materials>");
+    }
+
+    G4NistManager* nist = G4NistManager::Instance();
+
+    for (XMLNodePointer_t matNode = xml.GetChild(root); matNode != nullptr; matNode = xml.GetNext(matNode)) {
+        if (std::string(xml.GetNodeName(matNode)) != "material") continue;
+
+        std::string name = xml.GetAttr(matNode, "name");
+        std::string stateStr = xml.GetAttr(matNode, "state");
+
+        G4State state = kStateUndefined;
+        if (stateStr == "solid") state = kStateSolid;
+        else if (stateStr == "liquid") state = kStateLiquid;
+        else if (stateStr == "gas") state = kStateGas;
+
+        // density
+        double density = -1;
+        std::string unitStr;
+        for (XMLNodePointer_t dNode = xml.GetChild(matNode); dNode != nullptr; dNode = xml.GetNext(dNode)) {
+            if (std::string(xml.GetNodeName(dNode)) == "D") {
+                density = atof(xml.GetAttr(dNode, "value"));
+                unitStr = xml.GetAttr(dNode, "unit");
+                break;
+            }
+        }
+
+        if (density < 0 || unitStr.empty()) {
+            throw std::runtime_error("Material " + name + " must have <D value=\"...\" unit=\"...\"/> defined.");
+        }
+
+        
+        double densityFactor = 1.0;
+        if (unitStr == "g/cm3") densityFactor = g/cm3;
+        else if (unitStr == "kg/m3") densityFactor = kg/m3;
+        else throw std::runtime_error("Unknown density unit: " + unitStr);
+
+        //G4Material* material = new G4Material(name, density * densityFactor, 0, state);
+
+        std::vector<std::pair<G4Material*, double>> materialComponents;
+        std::vector<std::pair<G4Element*, double>> elementComponents;
+        double fractionSum = 0.0;
+
+        for (XMLNodePointer_t compNode = xml.GetChild(matNode); compNode != nullptr; compNode = xml.GetNext(compNode)) {
+            if (std::string(xml.GetNodeName(compNode)) != "component") continue;
+
+            const char* elementAttr = xml.GetAttr(compNode, "element");
+            const char* materialAttr = xml.GetAttr(compNode, "material");
+            const char* fractionAttr = xml.GetAttr(compNode, "fraction");
+
+            if (!fractionAttr) {
+            throw std::runtime_error("Component in material " + name + " is missing fraction attribute.");
+            }
+
+            double fraction = atof(fractionAttr);
+            fractionSum += fraction;
+
+            if (elementAttr) {
+            auto element = nist->FindOrBuildElement(elementAttr);
+            if (!element) throw std::runtime_error("Element " + std::string(elementAttr) + " not found");
+            elementComponents.emplace_back(element, fraction);
+            } else if (materialAttr) {
+            G4Material* baseMat = nullptr;
+
+            if (nist->FindOrBuildMaterial(materialAttr, false)) {
+                baseMat = nist->FindOrBuildMaterial(materialAttr);
+            } else if (customMaterials.count(materialAttr)) {
+                baseMat = customMaterials[materialAttr];
+            } else {
+                throw std::runtime_error("Material " + std::string(materialAttr) + " not found");
+            }
+
+            materialComponents.emplace_back(baseMat, fraction);
+            } else {
+            throw std::runtime_error("Component in material " + name + " must specify either element or material");
+            }
+        }
+
+        // validate the fractions
+        const double epsilon = 1e-6;
+        if (std::abs(fractionSum - 1.0) > epsilon) {
+            std::ostringstream oss;
+            oss << "Material " << name << ": fractions must sum to 1.0 (sum is " << fractionSum << ")";
+            throw std::runtime_error(oss.str());
+        }
+
+        // create material adding components
+        int nComponents = elementComponents.size() + materialComponents.size();
+        G4Material* material = new G4Material(name, density * densityFactor, nComponents, state);
+        for (const auto& [elem, frac] : elementComponents) {
+            material->AddElement(elem, frac);
+        }
+        for (const auto& [mat, frac] : materialComponents) {
+            material->AddMaterial(mat, frac);
+        }
+
+        customMaterials[name] = material;
+        G4cout << "Custom material loaded: " << name << G4endl;
+    }
+
+    xml.FreeDoc(doc);
+}
+
+
+G4Material* DetectorConstruction::GetMaterialOrCustom(const std::string& name) {
+    auto nist = G4NistManager::Instance();
+    G4Material* material = nist->FindOrBuildMaterial(name, false);
+
+    if (!material) {
+        auto it = customMaterials.find(name);
+        if (it != customMaterials.end()) {
+            material = it->second;
+        }
+    }
+
+    if (!material) {
+        throw std::runtime_error("Material '" + name + "' not found in NIST or custom definitions.");
+    }
+
+    G4cout << "\n[Material Info] Selected material: " << material->GetName() << G4endl;
+    G4cout << "  Density: " << material->GetDensity() / (g/cm3) << G4endl;
+    G4cout << "  State: " << material->GetState() << G4endl;
+    G4cout << "  Number of components: " << material->GetNumberOfElements() << G4endl;
+
+    for (size_t i = 0; i < material->GetNumberOfElements(); ++i) {
+        const G4Element* elem = material->GetElement(i);
+        double frac = material->GetFractionVector()[i];
+        G4cout << "    Component " << i << ": " << elem->GetName()
+               << " (" << elem->GetSymbol() << "), fraction: " << frac << G4endl;
+    }
+
+    G4cout << "----------------------------------------------\n" << G4endl;
+
+    return material;
+}
 

--- a/src/DetectorConstruction.h
+++ b/src/DetectorConstruction.h
@@ -9,6 +9,11 @@
 #include <G4VUserDetectorConstruction.hh>
 #include <G4VisAttributes.hh>
 #include <globals.hh>
+#include <TXMLEngine.h>
+
+#include <vector>
+#include <string>
+#include <map>
 
 
 class DetectorConstruction : public G4VUserDetectorConstruction {
@@ -30,6 +35,11 @@ private:
     const std::vector<std::pair<std::string, double>> configuration;
 
     double totalThickness = 0;
+
+    std::map<std::string, G4Material*> customMaterials;
+
+    void LoadCustomMaterialsFromXML(const std::string& filename);
+    G4Material* GetMaterialOrCustom(const std::string& name);
 };
 
 


### PR DESCRIPTION
This is a PR to define and load custom materials from an external file. In this case I use XML, but maybe we can try another type(?)

Modified files:
`CMakeLists.txt`: added `ROOT::XMLIO` dependency to enable XML parsing using `TXMLEngine`

In the `DetectorConstruction `class I added the following methods:
`void LoadCustomMaterialsFromXML(const std::string& filename);`
Loads and validate custom material definitions from an XML file

`G4Material* GetMAterialOrCustom(const std::string& name);`
Retrieves a material either from the standard NIST database or from previously loaded custom materials

As example, I have included `materials.xml`

NOTE: I am currently generating some simulation files to validate 